### PR TITLE
Removed “web” from keywords, added CHANGELOG.md, and added Japanese s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+0.1.0 - 25 May 2025
+
+* First release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/YusukeYoshida8849/actix-web-request-uuid"
 homepage = "https://github.com/YusukeYoshida8849/actix-web-request-uuid"
 documentation = "https://docs.rs/actix-web-request-uuid"
-keywords = ["actix", "actix-web", "web", "middleware", "request-id", "uuid"]
+keywords = ["actix", "actix-web", "middleware", "request-id", "uuid"]
 edition = "2021"
 
 [badges]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A Rust library to add request ID functionality with the actix-web framework.
 [![Documentation](https://docs.rs/actix-web-request-uuid/badge.svg)](https://docs.rs/actix-web-request-uuid)
 [![License](https://img.shields.io/crates/l/actix-web-request-uuid)](https://github.com/YusukeYoshida8849/actix-web-request-uuid#license)
 
+## Japanese
+
+Please refer to [README.en.md](./README.ja.md) .
+
 ## Installation
 
 Add this to your `Cargo.toml`:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Rust library to add request ID functionality with the actix-web framework.
 
 ## Japanese
 
-Please refer to [README.en.md](./README.ja.md) .
+Please refer to [README.ja.md](./README.ja.md) .
 
 ## Installation
 


### PR DESCRIPTION
This pull request introduces the first release of the `actix-web-request-uuid` library, updates metadata, and adds a Japanese README link for multilingual support. Below are the key changes:

### Release and Documentation:
* Added the initial release version `0.1.0` with a release date of 25 May 2025 to `CHANGELOG.md`.

### Metadata Updates:
* Removed the redundant `web` keyword from the `keywords` list in `Cargo.toml` to streamline metadata.

### Multilingual Support:
* Added a link in `README.md` to a Japanese version of the README (`README.ja.md`) for Japanese-speaking users.…ection to README.md.