### PR TITLE
Updated to version 0.2.0 with API changes. RequestIDMiddleware::new()…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+0.2.0 - 25 May 2025
+
+## Breaking Changes
+* **API Change**: `RequestIDMiddleware::new()` no longer takes parameters
+  - Old: `RequestIDMiddleware::new(36)`
+  - New: `RequestIDMiddleware::new()` (uses default 36-character UUID)
+
+## New Features
+* **Added `with_id_length(length: usize)` method** for customizing request ID length
+  - Allows generating IDs from 1 to 36 characters
+  - Panics if length is 0 for safety
+  - Example: `RequestIDMiddleware::new().with_id_length(16)`
+
+## Improvements
+* **Simplified API**: Default constructor now uses standard UUID length (36 characters)
+* **Better method chaining**: All configuration methods can be chained fluently
+* **Enhanced documentation**: Added comprehensive usage guide and examples
+* **Updated examples**: All examples now use the new API
+
+## Migration Guide
+```rust
+// Before (0.1.x)
+RequestIDMiddleware::new(36)
+RequestIDMiddleware::new(16)
+
+// After (0.2.x)
+RequestIDMiddleware::new()                    // Default 36 characters
+RequestIDMiddleware::new().with_id_length(16) // Custom length
+```
+
 0.1.0 - 25 May 2025
 
 * First release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "actix-web-request-uuid"
 description = "Request UUID middleware for actix-web"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Yusuke Yoshida <written-crib-taco@duck.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -20,3 +20,8 @@ uuid = { version = "1.17.0", features = ["v4"] }
 
 [dev-dependencies]
 actix-rt = "2.10.0"
+serde_json = "1.0"
+
+[[example]]
+name = "custom_length"
+path = "examples/custom_length.rs"

--- a/README.ja.md
+++ b/README.ja.md
@@ -28,7 +28,7 @@ use actix_web_request_uuid::RequestIDMiddlware;
 async fn main() -> std::io::Result<()> {
     HttpServer::new(
         || App::new()
-            .wrap(RequestIDMiddleware::new(36))
+            .wrap(RequestIDMiddleware::new())
             .service(web::resource("/").to(|| HttpResponse::Ok())))
         .bind("127.0.0.1:59880")?
         .run()
@@ -67,6 +67,7 @@ async fn my_service() -> Result<(), Error> {
 #### 2. **豊富なカスタマイズオプション**
 元のプロジェクトはUUID v4のみでしたが、多様な形式をサポート：
 
+- **ID長変更**: `with_id_length()` - 1文字から36文字までの任意の長さを指定
 - **フルUUID形式**: `with_full_uuid()` - 36文字、ハイフン付き
 - **シンプルUUID形式**: `with_simple_uuid()` - 32文字、ハイフンなし
 - **カスタム形式**: `with_custom_uuid_format()` - 独自のフォーマッター
@@ -75,7 +76,7 @@ async fn my_service() -> Result<(), Error> {
 
 ```rust
 // 設定例
-let middleware = RequestIDMiddleware::new(32)
+let middleware = RequestIDMiddleware::new()
     .with_simple_uuid()
     .header_name("X-Request-ID")
     .generator(|| format!("req-{}", Uuid::new_v4().simple()));

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ use actix_web_request_uuid::RequestIDMiddleware;
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
         App::new()
-            .wrap(RequestIDMiddleware::new(36))
+            .wrap(RequestIDMiddleware::new())
             .service(web::resource("/").to(|| HttpResponse::Ok()))
     })
     .bind("127.0.0.1:59880")?
@@ -72,6 +72,7 @@ async fn my_service() -> Result<(), Error> {
 #### 2. **Rich Customization Options**
 While the original project only supported UUID v4, this version supports various formats:
 
+- **Custom ID length**: `with_id_length()` - Specify any length from 1 to 36 characters
 - **Full UUID format**: `with_full_uuid()` - 36 characters with hyphens
 - **Simple UUID format**: `with_simple_uuid()` - 32 characters without hyphens
 - **Custom format**: `with_custom_uuid_format()` - Custom formatters
@@ -80,7 +81,7 @@ While the original project only supported UUID v4, this version supports various
 
 ```rust
 // Configuration example
-let middleware = RequestIDMiddleware::new(32)
+let middleware = RequestIDMiddleware::new()
     .with_simple_uuid()
     .header_name("X-Request-ID")
     .generator(|| format!("req-{}", Uuid::new_v4().simple()));

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -1,0 +1,139 @@
+# actix-web-request-uuid Usage Guide
+
+## ID Length Customization
+
+The `with_id_length()` method allows you to customize the length of generated request IDs. This is useful when you need shorter IDs for performance reasons or specific length requirements.
+
+### Basic Usage
+
+```rust
+use actix_web::{App, HttpServer, web};
+use actix_web_request_uuid::RequestIDMiddleware;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            // Default: 36-character UUID (with hyphens)
+            .wrap(RequestIDMiddleware::new())
+
+            // Custom: 16-character UUID (truncated)
+            .wrap(RequestIDMiddleware::new().with_id_length(16))
+
+            // Custom: 8-character UUID (very short)
+            .wrap(RequestIDMiddleware::new().with_id_length(8))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+```
+
+### How It Works
+
+When you specify a custom length:
+- If the length is **less than 36**, the UUID is truncated to the specified length
+- If the length is **36 or more**, the full UUID (36 characters) is used
+- The method **panics** if you specify a length of 0
+
+### Examples
+
+```rust
+// 36 characters (default)
+RequestIDMiddleware::new()
+// Output: "550e8400-e29b-41d4-a716-446655440000"
+
+// 16 characters
+RequestIDMiddleware::new().with_id_length(16)
+// Output: "550e8400-e29b-41"
+
+// 8 characters
+RequestIDMiddleware::new().with_id_length(8)
+// Output: "550e8400"
+
+// 4 characters (very short, might not be unique enough)
+RequestIDMiddleware::new().with_id_length(4)
+// Output: "550e"
+```
+
+### Combining with Other Methods
+
+The `with_id_length()` method can be combined with other configuration methods:
+
+```rust
+// Short IDs with custom header
+RequestIDMiddleware::new()
+    .with_id_length(12)
+    .header_name("X-Trace-ID")
+
+// Note: with_full_uuid() and with_simple_uuid() will override the length setting
+RequestIDMiddleware::new()
+    .with_id_length(16)      // This will be overridden
+    .with_full_uuid()        // Forces 36 characters with hyphens
+
+// Custom generator ignores length setting
+RequestIDMiddleware::new()
+    .with_id_length(16)      // This will be ignored
+    .generator(|| "custom-id-12345".to_string())
+```
+
+### Best Practices
+
+1. **Uniqueness vs Performance Trade-off**
+   - Shorter IDs are faster to generate and transmit
+   - But they have higher collision probability
+   - Recommended minimum: 8-12 characters for most applications
+
+2. **Common Length Choices**
+   - **36 characters**: Full UUID, maximum uniqueness
+   - **32 characters**: UUID without hyphens (use `with_simple_uuid()`)
+   - **16 characters**: Good balance of uniqueness and size
+   - **8 characters**: Minimum recommended for production
+
+3. **Testing Different Lengths**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_id_lengths() {
+        // Test that generated IDs match expected lengths
+        let lengths = vec![8, 12, 16, 24, 32, 36, 50];
+
+        for &len in &lengths {
+            let middleware = RequestIDMiddleware::new().with_id_length(len);
+            let expected_len = len.min(36); // Max length is 36
+            assert_eq!(middleware.get_id_length(), len);
+        }
+    }
+}
+```
+
+### Error Handling
+
+```rust
+// This will panic!
+let middleware = RequestIDMiddleware::new().with_id_length(0);
+// Error: "Request ID length must be greater than 0"
+
+// Safe way to handle dynamic lengths
+fn create_middleware(length: usize) -> Result<RequestIDMiddleware, &'static str> {
+    if length == 0 {
+        Err("ID length must be greater than 0")
+    } else {
+        Ok(RequestIDMiddleware::new().with_id_length(length))
+    }
+}
+```
+
+### Performance Considerations
+
+Shorter IDs provide several benefits:
+- Less memory usage
+- Faster string operations
+- Smaller HTTP headers
+- Reduced log file sizes
+
+However, ensure your chosen length provides sufficient uniqueness for your use case.

--- a/examples/custom_length.rs
+++ b/examples/custom_length.rs
@@ -1,0 +1,53 @@
+use actix_web::{web, App, HttpResponse, HttpServer};
+use actix_web_request_uuid::{get_current_request_id, RequestIDMiddleware};
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    println!("Starting server with custom request ID configurations...");
+
+    HttpServer::new(|| {
+        App::new()
+            // Default configuration (36 characters UUID)
+            .service(
+                web::scope("/default")
+                    .wrap(RequestIDMiddleware::new())
+                    .route("", web::get().to(handler)),
+            )
+            // Custom length configuration (16 characters)
+            .service(
+                web::scope("/short")
+                    .wrap(RequestIDMiddleware::new().with_id_length(16))
+                    .route("", web::get().to(handler)),
+            )
+            // Custom length configuration (8 characters)
+            .service(
+                web::scope("/tiny")
+                    .wrap(RequestIDMiddleware::new().with_id_length(8))
+                    .route("", web::get().to(handler)),
+            )
+            // Full UUID format
+            .service(
+                web::scope("/full")
+                    .wrap(RequestIDMiddleware::new().with_full_uuid())
+                    .route("", web::get().to(handler)),
+            )
+            // Simple UUID format (no hyphens)
+            .service(
+                web::scope("/simple")
+                    .wrap(RequestIDMiddleware::new().with_simple_uuid())
+                    .route("", web::get().to(handler)),
+            )
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+
+async fn handler() -> HttpResponse {
+    let request_id = get_current_request_id().unwrap_or_else(|| "unknown".to_string());
+    HttpResponse::Ok().json(serde_json::json!({
+        "message": "Hello!",
+        "request_id": request_id,
+        "id_length": request_id.len()
+    }))
+}


### PR DESCRIPTION
This pull request introduces significant updates to the `actix-web-request-uuid` library, including breaking changes, new features, and improvements to the API. The most notable changes include the removal of parameters from the `RequestIDMiddleware::new()` constructor, the addition of a `with_id_length()` method for customizing request ID lengths, and updates to documentation and examples to reflect the new API. Below is a summary of the most important changes:

### Breaking Changes
* The `RequestIDMiddleware::new()` constructor no longer accepts parameters. It now defaults to generating 36-character UUIDs. To specify a custom length, use the new `with_id_length()` method. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R30) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L197-R234)

### New Features
* Introduced the `with_id_length(length: usize)` method, allowing customization of request ID lengths between 1 and 36 characters. This method panics if the length is set to 0. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R30) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L197-R234)
* Added a new example file, `examples/custom_length.rs`, demonstrating various configurations for request ID lengths and formats.

### Documentation Updates
* Expanded the `USAGE_GUIDE.md` with detailed instructions on using the `with_id_length()` method, including examples, best practices, and performance considerations.
* Updated `README.md` and `README.ja.md` to reflect the new API, replacing outdated examples and adding descriptions of the `with_id_length()` method. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75) [[3]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L31-R31) [[4]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L78-R79)

### Codebase Improvements
* Simplified the `RequestIDMiddleware` implementation by removing redundant logic from the constructor and delegating ID length customization to the `with_id_length()` method.
* Enhanced method chaining for all configuration methods, improving API fluency.

### Test Updates
* Updated all test cases in `src/lib.rs` to use the new `RequestIDMiddleware::new()` constructor and the `with_id_length()` method where applicable. Added a test to ensure the `with_id_length(0)` method panics as expected. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L414-R425) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L527-R544) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L750-R761)