### PR TITLE
Feature/v0.2.0 main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+0.2.0 - 25 May 2025
+
+## Breaking Changes
+* **API Change**: `RequestIDMiddleware::new()` no longer takes parameters
+  - Old: `RequestIDMiddleware::new(36)`
+  - New: `RequestIDMiddleware::new()` (uses default 36-character UUID)
+
+## New Features
+* **Added `with_id_length(length: usize)` method** for customizing request ID length
+  - Allows generating IDs from 1 to 36 characters
+  - Panics if length is 0 for safety
+  - Example: `RequestIDMiddleware::new().with_id_length(16)`
+
+## Improvements
+* **Simplified API**: Default constructor now uses standard UUID length (36 characters)
+* **Better method chaining**: All configuration methods can be chained fluently
+* **Enhanced documentation**: Added comprehensive usage guide and examples
+* **Updated examples**: All examples now use the new API
+
+## Migration Guide
+```rust
+// Before (0.1.x)
+RequestIDMiddleware::new(36)
+RequestIDMiddleware::new(16)
+
+// After (0.2.x)
+RequestIDMiddleware::new()                    // Default 36 characters
+RequestIDMiddleware::new().with_id_length(16) // Custom length
+```
+
 0.1.0 - 25 May 2025
 
 * First release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "actix-web-request-uuid"
 description = "Request UUID middleware for actix-web"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Yusuke Yoshida <written-crib-taco@duck.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -20,3 +20,8 @@ uuid = { version = "1.17.0", features = ["v4"] }
 
 [dev-dependencies]
 actix-rt = "2.10.0"
+serde_json = "1.0"
+
+[[example]]
+name = "custom_length"
+path = "examples/custom_length.rs"

--- a/README.ja.md
+++ b/README.ja.md
@@ -28,7 +28,7 @@ use actix_web_request_uuid::RequestIDMiddlware;
 async fn main() -> std::io::Result<()> {
     HttpServer::new(
         || App::new()
-            .wrap(RequestIDMiddleware::new(36))
+            .wrap(RequestIDMiddleware::new())
             .service(web::resource("/").to(|| HttpResponse::Ok())))
         .bind("127.0.0.1:59880")?
         .run()
@@ -67,6 +67,7 @@ async fn my_service() -> Result<(), Error> {
 #### 2. **豊富なカスタマイズオプション**
 元のプロジェクトはUUID v4のみでしたが、多様な形式をサポート：
 
+- **ID長変更**: `with_id_length()` - 1文字から36文字までの任意の長さを指定
 - **フルUUID形式**: `with_full_uuid()` - 36文字、ハイフン付き
 - **シンプルUUID形式**: `with_simple_uuid()` - 32文字、ハイフンなし
 - **カスタム形式**: `with_custom_uuid_format()` - 独自のフォーマッター
@@ -75,7 +76,7 @@ async fn my_service() -> Result<(), Error> {
 
 ```rust
 // 設定例
-let middleware = RequestIDMiddleware::new(32)
+let middleware = RequestIDMiddleware::new()
     .with_simple_uuid()
     .header_name("X-Request-ID")
     .generator(|| format!("req-{}", Uuid::new_v4().simple()));

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ use actix_web_request_uuid::RequestIDMiddleware;
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
         App::new()
-            .wrap(RequestIDMiddleware::new(36))
+            .wrap(RequestIDMiddleware::new())
             .service(web::resource("/").to(|| HttpResponse::Ok()))
     })
     .bind("127.0.0.1:59880")?
@@ -72,6 +72,7 @@ async fn my_service() -> Result<(), Error> {
 #### 2. **Rich Customization Options**
 While the original project only supported UUID v4, this version supports various formats:
 
+- **Custom ID length**: `with_id_length()` - Specify any length from 1 to 36 characters
 - **Full UUID format**: `with_full_uuid()` - 36 characters with hyphens
 - **Simple UUID format**: `with_simple_uuid()` - 32 characters without hyphens
 - **Custom format**: `with_custom_uuid_format()` - Custom formatters
@@ -80,7 +81,7 @@ While the original project only supported UUID v4, this version supports various
 
 ```rust
 // Configuration example
-let middleware = RequestIDMiddleware::new(32)
+let middleware = RequestIDMiddleware::new()
     .with_simple_uuid()
     .header_name("X-Request-ID")
     .generator(|| format!("req-{}", Uuid::new_v4().simple()));

--- a/USAGE_GUIDE.md
+++ b/USAGE_GUIDE.md
@@ -1,0 +1,139 @@
+# actix-web-request-uuid Usage Guide
+
+## ID Length Customization
+
+The `with_id_length()` method allows you to customize the length of generated request IDs. This is useful when you need shorter IDs for performance reasons or specific length requirements.
+
+### Basic Usage
+
+```rust
+use actix_web::{App, HttpServer, web};
+use actix_web_request_uuid::RequestIDMiddleware;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    HttpServer::new(|| {
+        App::new()
+            // Default: 36-character UUID (with hyphens)
+            .wrap(RequestIDMiddleware::new())
+
+            // Custom: 16-character UUID (truncated)
+            .wrap(RequestIDMiddleware::new().with_id_length(16))
+
+            // Custom: 8-character UUID (very short)
+            .wrap(RequestIDMiddleware::new().with_id_length(8))
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+```
+
+### How It Works
+
+When you specify a custom length:
+- If the length is **less than 36**, the UUID is truncated to the specified length
+- If the length is **36 or more**, the full UUID (36 characters) is used
+- The method **panics** if you specify a length of 0
+
+### Examples
+
+```rust
+// 36 characters (default)
+RequestIDMiddleware::new()
+// Output: "550e8400-e29b-41d4-a716-446655440000"
+
+// 16 characters
+RequestIDMiddleware::new().with_id_length(16)
+// Output: "550e8400-e29b-41"
+
+// 8 characters
+RequestIDMiddleware::new().with_id_length(8)
+// Output: "550e8400"
+
+// 4 characters (very short, might not be unique enough)
+RequestIDMiddleware::new().with_id_length(4)
+// Output: "550e"
+```
+
+### Combining with Other Methods
+
+The `with_id_length()` method can be combined with other configuration methods:
+
+```rust
+// Short IDs with custom header
+RequestIDMiddleware::new()
+    .with_id_length(12)
+    .header_name("X-Trace-ID")
+
+// Note: with_full_uuid() and with_simple_uuid() will override the length setting
+RequestIDMiddleware::new()
+    .with_id_length(16)      // This will be overridden
+    .with_full_uuid()        // Forces 36 characters with hyphens
+
+// Custom generator ignores length setting
+RequestIDMiddleware::new()
+    .with_id_length(16)      // This will be ignored
+    .generator(|| "custom-id-12345".to_string())
+```
+
+### Best Practices
+
+1. **Uniqueness vs Performance Trade-off**
+   - Shorter IDs are faster to generate and transmit
+   - But they have higher collision probability
+   - Recommended minimum: 8-12 characters for most applications
+
+2. **Common Length Choices**
+   - **36 characters**: Full UUID, maximum uniqueness
+   - **32 characters**: UUID without hyphens (use `with_simple_uuid()`)
+   - **16 characters**: Good balance of uniqueness and size
+   - **8 characters**: Minimum recommended for production
+
+3. **Testing Different Lengths**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_id_lengths() {
+        // Test that generated IDs match expected lengths
+        let lengths = vec![8, 12, 16, 24, 32, 36, 50];
+
+        for &len in &lengths {
+            let middleware = RequestIDMiddleware::new().with_id_length(len);
+            let expected_len = len.min(36); // Max length is 36
+            assert_eq!(middleware.get_id_length(), len);
+        }
+    }
+}
+```
+
+### Error Handling
+
+```rust
+// This will panic!
+let middleware = RequestIDMiddleware::new().with_id_length(0);
+// Error: "Request ID length must be greater than 0"
+
+// Safe way to handle dynamic lengths
+fn create_middleware(length: usize) -> Result<RequestIDMiddleware, &'static str> {
+    if length == 0 {
+        Err("ID length must be greater than 0")
+    } else {
+        Ok(RequestIDMiddleware::new().with_id_length(length))
+    }
+}
+```
+
+### Performance Considerations
+
+Shorter IDs provide several benefits:
+- Less memory usage
+- Faster string operations
+- Smaller HTTP headers
+- Reduced log file sizes
+
+However, ensure your chosen length provides sufficient uniqueness for your use case.

--- a/examples/custom_length.rs
+++ b/examples/custom_length.rs
@@ -1,0 +1,53 @@
+use actix_web::{web, App, HttpResponse, HttpServer};
+use actix_web_request_uuid::{get_current_request_id, RequestIDMiddleware};
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    println!("Starting server with custom request ID configurations...");
+
+    HttpServer::new(|| {
+        App::new()
+            // Default configuration (36 characters UUID)
+            .service(
+                web::scope("/default")
+                    .wrap(RequestIDMiddleware::new())
+                    .route("", web::get().to(handler)),
+            )
+            // Custom length configuration (16 characters)
+            .service(
+                web::scope("/short")
+                    .wrap(RequestIDMiddleware::new().with_id_length(16))
+                    .route("", web::get().to(handler)),
+            )
+            // Custom length configuration (8 characters)
+            .service(
+                web::scope("/tiny")
+                    .wrap(RequestIDMiddleware::new().with_id_length(8))
+                    .route("", web::get().to(handler)),
+            )
+            // Full UUID format
+            .service(
+                web::scope("/full")
+                    .wrap(RequestIDMiddleware::new().with_full_uuid())
+                    .route("", web::get().to(handler)),
+            )
+            // Simple UUID format (no hyphens)
+            .service(
+                web::scope("/simple")
+                    .wrap(RequestIDMiddleware::new().with_simple_uuid())
+                    .route("", web::get().to(handler)),
+            )
+    })
+    .bind("127.0.0.1:8080")?
+    .run()
+    .await
+}
+
+async fn handler() -> HttpResponse {
+    let request_id = get_current_request_id().unwrap_or_else(|| "unknown".to_string());
+    HttpResponse::Ok().json(serde_json::json!({
+        "message": "Hello!",
+        "request_id": request_id,
+        "id_length": request_id.len()
+    }))
+}


### PR DESCRIPTION
This pull request introduces version `0.2.0` of the `actix-web-request-uuid` crate, featuring a breaking change to the `RequestIDMiddleware` API, new functionality for customizing request ID lengths, and extensive updates to documentation and examples. The most significant changes include the removal of the parameterized constructor for `RequestIDMiddleware`, the addition of the `with_id_length()` method, and updates to tests and examples to reflect the new API.

### Breaking Changes
* The `RequestIDMiddleware::new()` method no longer accepts parameters. It now defaults to generating 36-character UUIDs. (`CHANGELOG.md`, `src/lib.rs`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R30) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L197-R234)
* Updated all examples and tests to use the new `RequestIDMiddleware::new()` method without parameters. (`README.md`, `README.ja.md`, `src/lib.rs`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R35) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L31-R31) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L414-R425)

### New Features
* Added the `with_id_length(length: usize)` method for customizing the length of generated request IDs (1–36 characters). It panics if a length of 0 is provided. (`src/lib.rs`)
* Added a new example (`examples/custom_length.rs`) demonstrating custom ID lengths and other configurations.

### Documentation Updates
* Enhanced documentation in `README.md`, `README.ja.md`, and the new `USAGE_GUIDE.md` to include details about the new API, customization options, and usage examples. (`README.md`, `README.ja.md`, `USAGE_GUIDE.md`) [[1]](diffhunk://#diff-0a1e083cbf2b1feb802ae49d335ffcd6a675dbc9d4c92811b50b147cbcda2aeaR1-R139) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75) [[3]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336R70)
* Added a migration guide to `CHANGELOG.md` for transitioning from version `0.1.x` to `0.2.x`.

### Dependency and Metadata Updates
* Updated the crate version to `0.2.0` in `Cargo.toml`.
* Added `serde_json` as a development dependency and a new example entry in `Cargo.toml`.

### Test Updates
* Updated all tests to use the new `RequestIDMiddleware::new()` method and the `with_id_length()` method where applicable. (`src/lib.rs`) [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L414-R425) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L750-R761)